### PR TITLE
feat: #328 swal 세팅 및 닉네임, 비밀번호, 프로필 alert 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "react-scripts": "5.0.1",
         "react-select": "^5.7.0",
         "styled-components": "^5.3.6",
+        "sweetalert2": "^11.7.5",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
@@ -17802,6 +17803,15 @@
       "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
       "dependencies": {
         "boolbase": "~1.0.0"
+      }
+    },
+    "node_modules/sweetalert2": {
+      "version": "11.7.5",
+      "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-11.7.5.tgz",
+      "integrity": "sha512-RBPKdK8Uf9/bz9r4vy7x6sGqf0MioSXt1po1lAwwcl3AwbjHVTc5S0yud4ZJKU1EhvJFVDrFoqIpHwWERwZJEA==",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/limonte"
       }
     },
     "node_modules/symbol-tree": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-scripts": "5.0.1",
     "react-select": "^5.7.0",
     "styled-components": "^5.3.6",
+    "sweetalert2": "^11.7.5",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/src/component/template/MypageView .jsx
+++ b/src/component/template/MypageView .jsx
@@ -2,6 +2,8 @@ import React from "react";
 import Footer from "../organism/Footer";
 import SectionListHeader from "../molecule/SectionListHeader";
 import styled from "styled-components";
+import Swal from 'sweetalert2'
+import { useState } from "react";
 
 /**
  * @param onClickRevoke: () => {}
@@ -10,6 +12,9 @@ import styled from "styled-components";
  */
 
 const MypageView = ({ onClickRevoke, onClickLogout }) => {
+    const [inputValue, setInputValue] = useState('');
+    const [password, setPassword] = useState('');
+
     return (
         <>
             <SectionListLayout>
@@ -21,19 +26,60 @@ const MypageView = ({ onClickRevoke, onClickLogout }) => {
                     <SectionListHeader
                         title={"닉네임 설정"}
                         onClick={() => {
-                            //여기에 swal inputAlert가 띄워져야 합니다.
+
+                            Swal.fire({
+                            title: '닉네임 변경',
+                            input: 'text',
+                            inputLabel: '변경할 닉네임을 써주세요!',
+                            inputValue: inputValue,
+                            showCancelButton: true,
+                            inputValidator: (value) => {
+                                if (!value) {
+                                return '변경할 닉네임을 입력해주세요!';
+                                }
+                            }
+                            }).then((result) => { 
+                            if (result.value) {
+                                const newNickname = result.value;
+                                setInputValue(newNickname);
+                                Swal.fire(`닉네임이 ${newNickname}로 바뀌었습니다!!`);
+                            }
+                            });
+                        
+                        
                         }}
                     ></SectionListHeader>
                     <SectionListHeader
                         title={"프로필 이미지 변경"}
                         onClick={() => {
-                            //여기에 swal alert가 띄워져야 합니다. ('준비중 입니다!')
+                            Swal.fire({
+                                title: '준비중입니다.'
+                              })
                         }}
                     ></SectionListHeader>
                     <SectionListHeader
                         title={"비밀번호 변경"}
                         onClick={() => {
-                            //여기에 swal inputAlert가 띄워져야 합니다.
+
+                            Swal.fire({
+                            title: '비밀번호 변경',
+                            input: 'password',
+                            inputLabel: '새로 변경할 비밀번호를 써주세요!',
+                            showCancelButton: true,
+                            inputValidator: (value) => {
+                                if (!value) {
+                                return '변경할 비밀번호를 입력해주세요!';
+                                }
+                            }
+                            }).then((result) => { 
+                            if (result.value) {
+                                const newPassword = result.value;
+                                setPassword(newPassword);
+                                Swal.fire(`비빌번호가 ${newPassword[0]+ '*'.repeat(newPassword.length-1)}로 바뀌었습니다!!`);
+                            }
+                            });
+                        
+                        
                         }}
                     ></SectionListHeader>
                     <SectionListHeader title={"로그아웃"} onClick={onClickLogout}></SectionListHeader>


### PR DESCRIPTION
-새로운 닉넴 비번을 usestate로 관리합니다.
 -닉넴 비번 형식 미적용(정규식X) 

1. 닉네임 변경 누를 시
![image](https://github.com/smu-capstone2023/fe-react-deploy/assets/105111234/e51ad5b1-5338-4039-88ac-f91c5975489f)

2. 프로필 이미지 변경 누를 시
![image](https://github.com/smu-capstone2023/fe-react-deploy/assets/105111234/0e0c889c-470a-4e40-bc2c-8e094341808c)

3. 비번 변경 누를 시
![image](https://github.com/smu-capstone2023/fe-react-deploy/assets/105111234/ced5955d-a519-491b-82df-3f5a684928fb)
