### PR TITLE
Bus notice

### DIFF
--- a/src/api/utils/getBusNotice.ts
+++ b/src/api/utils/getBusNotice.ts
@@ -1,8 +1,9 @@
 import { instance } from "api/interceptor";
+import { BusNoticeType } from "pages/Home";
 
-export const getBusNotice = () => {
+export const getBusNotice = () : Promise<boolean | BusNoticeType[]> => {
     return instance
-        .get(`/board/bus_notice`, {})
+        .get(`/board/bus_notice`)
         .then((response: any) => {
             return response.data;
         })

--- a/src/pages/Home/BusNotice.tsx
+++ b/src/pages/Home/BusNotice.tsx
@@ -8,17 +8,19 @@ const SectionContainer = styled.div`
     padding: 20px 20px 0 20px;
     display: flex;
     flex-direction: column;
+    flex-direction: row;
+    justify-content: space-between;
 `;
 
 interface BusNoticeProps {
-    BusNoticeLists: BusNoticeType[];
+    BusNoticeLists: BusNoticeType[] | boolean;
 }
 
 export default function BusNotice({BusNoticeLists} :BusNoticeProps) {
     const [toDayBusContent, setTodayBusContent] = useState<string | null>(null);
 
     const findTodayBusList = () => {
-        if (BusNoticeLists && BusNoticeLists.length > 0) {
+        if (Array.isArray(BusNoticeLists) && BusNoticeLists.length > 0) {
             setTodayBusContent(BusNoticeLists[0].title);
         } else {
             setTodayBusContent(null);
@@ -31,12 +33,7 @@ export default function BusNotice({BusNoticeLists} :BusNoticeProps) {
 
     return (
         <>
-            <SectionContainer
-                css={css`
-                    flex-direction: row;
-                    justify-content: space-between;
-                `}
-            >
+            <SectionContainer>
                 <p
                     css={css`
                         font-family: nexon-regular;
@@ -47,7 +44,7 @@ export default function BusNotice({BusNoticeLists} :BusNoticeProps) {
                     ⚠️ 오늘의 우회정보
                 </p>
             </SectionContainer>
-            {toDayBusContent === null &&
+            {!toDayBusContent &&
                 <div
                     css={css`
                         dislpay: flex;
@@ -65,7 +62,7 @@ export default function BusNotice({BusNoticeLists} :BusNoticeProps) {
                     </p>
                 </div>
             }
-            {toDayBusContent !== null &&
+            {toDayBusContent &&
                 <div
                     css={css`
                         display: flex;

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -33,7 +33,7 @@ export default function Home() {
     const [userInfo, setUserInfo] = useState<UserDto>();
     const [lostPreviewList, setLostPreviewList] = useState<IPreview[]>([]);
     const [majorPreviewList, setMajorPreviewList] = useState<IPreview[]>([]);
-    const [BusNoticeList, setBusNoticeList] = useState<BusNoticeType[]>([]);
+    const [BusNoticeList, setBusNoticeList] = useState<BusNoticeType[] | boolean>([]);
     useEffect(() => {
         getHotBoardPreviewList().then((response) => {
             if (response) {
@@ -53,7 +53,7 @@ export default function Home() {
                 }
             });
         }
-        getBusNotice().then((res :any)=>{
+        getBusNotice().then((res :(BusNoticeType[] | boolean))=>{
             if (res) {
                 setBusNoticeList(res);
             }


### PR DESCRIPTION
일단 버스 우회 정보의 가장 최신 정보 1개를 보여주는 방식으로 로직을 구현했습니다.
이유 : 공지사항이 업로드된 시점과 실제 우회가 일어날 날짜가 일치하지 않는 경우가 있기 때문입니다.

![image](https://github.com/smu-capstone2023/fe-react-deploy/assets/104924817/6ab9c844-07ed-400d-a51f-199138aafaf4)
